### PR TITLE
Fix nova_boot_in_batches_with_delay

### DIFF
--- a/browbeat/automate_workload_parameters.yml
+++ b/browbeat/automate_workload_parameters.yml
@@ -85,7 +85,7 @@
       set_fact:
         delay_time={{ [times|int * 0.024, 30] | max }}
         iterations_per_batch={{ times|int // 8 }}
-        num_tenant_networks={{ [times|int // 1250, 1] | max }}
+        num_tenants={{ [times|int // 1250, 1] | max }}
       when: "workload == 'nova-boot-in-batches-with-delay'"
 
     # Dynamic workloads boots approximately 18 VMs with m1.tiny-cirros flavor and 2 VMs with m1.tiny-centos flavor

--- a/browbeat/browbeat-config.yaml.j2
+++ b/browbeat/browbeat-config.yaml.j2
@@ -352,7 +352,8 @@ workloads:
         # Setting this value to a small multiple(1x or 2x) of the concurrency is optimal.
         # num_iterations_to_delay should always be lesser than iterations_per_batch.
         num_iterations_to_delay: 16
-        num_tenant_networks: {{ num_tenant_networks }}
+        num_tenants: {{ num_tenants }}
+        num_networks_per_tenant: 10
         file: rally/rally-plugins/nova/nova_boot_in_batches_with_delay.yml
 {% endif %}
 {% if workload == "dynamic-workloads" %}


### PR DESCRIPTION
This commit updates the parameters for the nova_boot_in_batches_with_delay workload as per the corresponding patch that has been added to Browbeat

Depends-on: https://review.opendev.org/c/x/browbeat/+/866574